### PR TITLE
Added warning when running in production with IS_HTTPS=false, updated cookies logic in src/app/api/auth/login

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -15,11 +15,13 @@ export async function POST(req: Request) {
 
             const res = NextResponse.json({ status: true, message: "Successfull authentication" });
 
+            const isHttps = process.env.NODE_ENV === 'production' && env.IS_HTTPS === true
+
             res.cookies.set('token', token, {
                 httpOnly: true,
                 path: '/',
                 maxAge: 60 * 60 * 24 * 7, // 7 days
-                secure: process.env.NODE_ENV === 'production' && env.IS_HTTPS,
+                secure: isHttps,
                 sameSite: 'strict',
             });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Script from 'next/script';
 import "./globals.css";
+import '@/lib/startup-warning';
 import {ColorSchemeScript, MantineColorScheme, mantineHtmlProps, MantineProvider} from '@mantine/core';
 import {cookies} from "next/headers";
 import {Notifications} from "@mantine/notifications";

--- a/src/lib/startup-warning.ts
+++ b/src/lib/startup-warning.ts
@@ -1,0 +1,8 @@
+// src/lib/startup-warning.ts
+import { env } from "@/env";
+
+if (env.IS_HTTPS === false && process.env.NODE_ENV === 'production') {
+    console.warn(
+        '⚠️ You are running in production over HTTP. Secure cookies will NOT work. Set IS_HTTPS=true if using HTTPS.'
+    );
+}


### PR DESCRIPTION
Added warning when running in production with IS_HTTPS=false, updated cookies logic in src/app/api/auth/login